### PR TITLE
Added TargetNames to definition.xml to support Drag'n'Drop using the "Se...

### DIFF
--- a/svgMap/Definition.xml
+++ b/svgMap/Definition.xml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ExtensionObject Label="SVG Map" Description="SVG Map" PageHeight="100000">
-  <Dimension Label="Region ID" Initial="RegionID" DropTarget="RegionID"/>
-  <Measurement Label="Measure" Initial="Sum(Num)" />
-  <Measurement Label="Color Expression" Initial="Sum(Num)" />
-  <Measurement Label="Popup Contents" Initial=""/>
+  <Dimension Label="Region ID" Initial="RegionID" DropTarget="RegionID" TargetName="Region Id"/>
+  <Measurement Label="Measure" Initial="Sum(Num)" TargetName="Measure" />
+  <Measurement Label="Color Expression" Initial="Sum(Num)" TargetName="Color Expression" />
+  <Measurement Label="Popup Contents" Initial="" TargetName="Popup Contents"/>
   <Text Label="Disabled Color" Type="color"/>
   <Text Label="Element Border" Type="checkbox"/>
   <Text Label="Map" Type="select" Select="none,africa.svg,argentina.svg,australia.svg,austria.svg,belgium.svg,brazil.svg,canada.svg,china.svg,denmark.svg,europe.svg,france_departments.svg,germany.svg,india.svg,japan.svg,luxembourg.svg,mexico.svg,netherlands.svg,norway.svg,pakistan.svg,peru.svg,poland.svg,russia.svg,saudi_arabia.svg,south_africa.svg,south_korea.svg,spain.svg,sweden_provinces.svg,sweden_counties.svg,switzerland.svg,taiwan.svg,turkey_regions_and_provinces.svg,uk.svg,us.svg,us_counties.svg,venezuela.svg,world.svg" SelectLabel="Select or Load a Map,Africa,Argentina,Australia,Austria,Belgium,Brazil,Canada,China,Denmark,Europe,France,Germany,India,Japan,Luxembourg,Mexico,Netherlands,Norway,Pakistan,Peru,Poland,Russia,Saudi Arabia,South Africa,South Korea,Spain,Sweden Provinces,Sweden Counties,Switzerland,Taiwan,Turkey,UK Counties,US,US Counties,Venezuela,World"/>


### PR DESCRIPTION
I have added a "TargetName" definition for dimensions and measures. Especially if you are demoing the extension it's really nice to open the dialog with all existing fields and just drag'n'drop them to the extension.
